### PR TITLE
Fix: Add `munch` dependency

### DIFF
--- a/getting-started-with-ai-observability.ipynb
+++ b/getting-started-with-ai-observability.ipynb
@@ -24,7 +24,7 @@
     "name": "title",
     "resultHeight": 74
    },
-   "source": "# Getting Started with AI Observability\n\nTo run, first install the following packages: `snowflake-ml-python`, `snowflake.core`, `trulens-core`, `trulens-providers-cortex`, `trulens-connectors-snowflake`\n\nhttps://github.com/Snowflake-Labs/sfguide-getting-started-with-ai-observability"
+   "source": "# Getting Started with AI Observability\n\nTo run, first install the following packages: `snowflake-ml-python`, `snowflake.core`, `trulens-core`, `munch`, `trulens-providers-cortex`, `trulens-connectors-snowflake`\n\nhttps://github.com/Snowflake-Labs/sfguide-getting-started-with-ai-observability"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
Probably due to package changes recently, I had to explicitly install `munch` in anaconda to create the RAG instrumentation in this cell: https://github.com/Snowflake-Labs/sfguide-getting-started-with-ai-observability/blob/main/getting-started-with-ai-observability.ipynb?short_path=19707af#L517-L573